### PR TITLE
Issue #55: Read topics from the database.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Michael Giesler (<michael@4horsemen.de>)
 Free Software Foundation, Inc. (http://fsf.org)
+Stephan Kreutzer, Bahnhofstraße 71, 74321 Bietigheim-Bissingen, GERMANY (http://www.skreutzer.de, <skreutzer@fsfe.org>).

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Michael Giesler (<michael@4horsemen.de>)
 Free Software Foundation, Inc. (http://fsf.org)
-Stephan Kreutzer, Bahnhofstraße 71, 74321 Bietigheim-Bissingen, GERMANY (http://www.skreutzer.de, <skreutzer@fsfe.org>).
+Stephan Kreutzer, Bahnhofstraße 71, 74321 Bietigheim-Bissingen, GERMANY (http://www.publishing-systems.org, <skreutzer@fsfe.org>).

--- a/www/app/Resources/views/default/index.html.twig
+++ b/www/app/Resources/views/default/index.html.twig
@@ -1,3 +1,23 @@
+{#
+Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
+
+This file is part of Dembelo.
+
+Dembelo is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Dembelo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License 3 for more details.
+
+You should have received a copy of the GNU Affero General Public License 3
+along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
+#}
+
+
 {% extends 'base.html.twig' %}
 
 {% block bodyid %}main-page{% endblock %}
@@ -9,52 +29,88 @@
         <div id="row1" class="row ">
             <div class="col-xs-12 bg-success">Lesezeichen</div>
         </div>
+        {% if topics[0] is defined or topics[1] is defined or topics[2] is defined or topics[3] is defined %}
         <div id="row2" class="row">
             <div class="col-xs-3">
-                <a href="{{ path('themenfeld', {'themeId': '1'}) }}">
-                    {% image '@DembeloMain/Resources/public/images/bg01.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 1" />
+                {% if topics[0]['id'] is defined and topics[0]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[0]['id']}) }}">
+                    {# Doesn't work, see https://github.com/kriswallsmith/assetic/issues/60 #}
+                    {#% image '@DembeloMain/Resources/public/images/bg_' ~ topics[0]['id'] ~ '.jpg' %#}
+                    {% image '@DembeloMain/Resources/public/images/bg02.jpg' %}
+                    <img src="{{ asset_url }}" alt="{{ topics[0]['name'] }}" />
                     {% endimage %}
                 </a>
+                {% endif %}
             </div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '2'}) }}">
+            <div class="col-xs-3">
+                {% if topics[1]['id'] is defined and topics[1]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[1]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg02.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 2" />
+                    <img src="{{ asset_url }}" alt="{{ topics[1]['name'] }}" />
                     {% endimage %}
-                </a></div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '3'}) }}">
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-xs-3">
+                {% if topics[2]['id'] is defined and topics[2]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[2]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg03.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 3" />
+                    <img src="{{ asset_url }}" alt="{{ topics[2]['name'] }}" />
                     {% endimage %}
-                </a></div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '4'}) }}">
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-xs-3">
+                {% if topics[3]['id'] is defined and topics[3]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[3]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg04.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 4" />
+                    <img src="{{ asset_url }}" alt="{{ topics[3]['name'] }}" />
                     {% endimage %}
-                </a></div>
+                </a>
+                {% endif %}
+            </div>
         </div>
+        {% endif %}
+        {% if topics[4] is defined or topics[5] is defined or topics[6] is defined or topics[7] is defined %}
         <div id="row3" class="row">
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '5'}) }}">
+            <div class="col-xs-3">
+                {% if topics[4]['id'] is defined and topics[4]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[4]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg05.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 5" />
+                    <img src="{{ asset_url }}" alt="{{ topics[4]['name'] }}" />
                     {% endimage %}
-                </a></div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '6'}) }}">
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-xs-3">
+                {% if topics[5]['id'] is defined and topics[5]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[5]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg06.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 6" />
+                    <img src="{{ asset_url }}" alt="{{ topics[5]['name'] }}" />
                     {% endimage %}
-                </a></div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '7'}) }}">
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-xs-3">
+                {% if topics[6]['id'] is defined and topics[6]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[6]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg07.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 7" />
+                    <img src="{{ asset_url }}" alt="{{ topics[6]['name'] }}" />
                     {% endimage %}
-                </a></div>
-            <div class="col-xs-3"><a href="{{ path('themenfeld', {'themeId': '8'}) }}">
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-xs-3">
+                {% if topics[7]['id'] is defined and topics[7]['name'] is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[7]['id']}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg08.jpg' %}
-                    <img src="{{ asset_url }}" alt="Themenfeld 8" />
+                    <img src="{{ asset_url }}" alt="{{ topics[7]['name'] }}" />
                     {% endimage %}
-                </a></div>
+                </a>
+                {% endif %}
+            </div>
         </div>
+        {% endif %}
         <div id="row4" class="row ">
             <div class="col-xs-12 bg-danger">[10]</div>
         </div>

--- a/www/app/Resources/views/default/index.html.twig
+++ b/www/app/Resources/views/default/index.html.twig
@@ -32,39 +32,39 @@ along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
         {% if topics[0] is defined or topics[1] is defined or topics[2] is defined or topics[3] is defined %}
         <div id="row2" class="row">
             <div class="col-xs-3">
-                {% if topics[0]['id'] is defined and topics[0]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[0]['id']}) }}">
+                {% if topics[0].id is defined and topics[0].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[0].id}) }}">
                     {# Doesn't work, see https://github.com/kriswallsmith/assetic/issues/60 #}
-                    {#% image '@DembeloMain/Resources/public/images/bg_' ~ topics[0]['id'] ~ '.jpg' %#}
+                    {#% image '@DembeloMain/Resources/public/images/bg_' ~ topics[0].id ~ '.jpg' %#}
                     {% image '@DembeloMain/Resources/public/images/bg02.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[0]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[0].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[1]['id'] is defined and topics[1]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[1]['id']}) }}">
+                {% if topics[1].id is defined and topics[1].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[1].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg02.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[1]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[1].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[2]['id'] is defined and topics[2]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[2]['id']}) }}">
+                {% if topics[2].id is defined and topics[2].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[2].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg03.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[2]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[2].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[3]['id'] is defined and topics[3]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[3]['id']}) }}">
+                {% if topics[3].id is defined and topics[3].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[3].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg04.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[3]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[3].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
@@ -74,37 +74,37 @@ along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
         {% if topics[4] is defined or topics[5] is defined or topics[6] is defined or topics[7] is defined %}
         <div id="row3" class="row">
             <div class="col-xs-3">
-                {% if topics[4]['id'] is defined and topics[4]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[4]['id']}) }}">
+                {% if topics[4].id is defined and topics[4].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[4].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg05.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[4]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[4].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[5]['id'] is defined and topics[5]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[5]['id']}) }}">
+                {% if topics[5].id is defined and topics[5].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[5].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg06.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[5]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[5].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[6]['id'] is defined and topics[6]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[6]['id']}) }}">
+                {% if topics[6].id is defined and topics[6].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[6].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg07.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[6]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[6].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}
             </div>
             <div class="col-xs-3">
-                {% if topics[7]['id'] is defined and topics[7]['name'] is defined %}
-                <a href="{{ path('themenfeld', {'themeId': topics[7]['id']}) }}">
+                {% if topics[7].id is defined and topics[7].name is defined %}
+                <a href="{{ path('themenfeld', {'themeId': topics[7].id}) }}">
                     {% image '@DembeloMain/Resources/public/images/bg08.jpg' %}
-                    <img src="{{ asset_url }}" alt="{{ topics[7]['name'] }}" />
+                    <img src="{{ asset_url }}" alt="{{ topics[7].name }}" />
                     {% endimage %}
                 </a>
                 {% endif %}

--- a/www/app/Resources/views/default/read.html.twig
+++ b/www/app/Resources/views/default/read.html.twig
@@ -26,16 +26,6 @@ along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
 
 {% block body %}
 
-{% if textnodeText is defined %}
-
 {{ textnodeText | raw }}
-
-{% else %}
-
-<p>
-Kein Text vorhanden.
-</p>
-
-{% endif %}
 
 {% endblock %}

--- a/www/app/Resources/views/default/read.html.twig
+++ b/www/app/Resources/views/default/read.html.twig
@@ -1,3 +1,23 @@
+{#
+Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
+
+This file is part of Dembelo.
+
+Dembelo is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Dembelo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License 3 for more details.
+
+You should have received a copy of the GNU Affero General Public License 3
+along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
+#}
+
+
 {% extends 'base.html.twig' %}
 
 {% block skipcssclass %}{% endblock %}
@@ -5,121 +25,17 @@
 {% block bodyid %}content-page{% endblock %}
 
 {% block body %}
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
+
+{% if textnodeText is defined %}
+
+{{ textnodeText | raw }}
+
+{% else %}
 
 <p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.   </p>
+Kein Text vorhanden.
+</p>
 
-<p>
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.   </p>
+{% endif %}
 
-<p>
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.   </p>
-
-<p>
-At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.   </p>
-
-<p>
-Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.   </p>
-
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.   </p>
-
-<p>
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.   </p>
-
-<p>
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.   </p>
-
-<p>
-At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore
-dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.   </p>
-
-<p>
-Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et 
-justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.   </p>
-
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.   </p>
-
-<p>
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.   </p>
-
-<p>
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit 
-amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.   </p>
-
-<p>
-At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.   </p>
-
-<p>
-Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.   </p>
-
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam 
-voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.   </p>
-
-<p>
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.   </p>
-
-<p>
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.   </p>
-
-<p>
-At vero eos et accusam et justo duo
-dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt 
-justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.   </p>
-
-<p>
-Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.   </p>
-
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.   </p>
-
-<p>
-Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure 
-dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.   </p>
-
-<p>
-Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.   </p>
-
-<p>
-At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.   </p>
-
-<p>
-Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.   </p>
-
-<p>
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.   </p>
-
-<p>
-Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut</p>
 {% endblock %}

--- a/www/app/Resources/views/user/register.html.twig
+++ b/www/app/Resources/views/user/register.html.twig
@@ -1,3 +1,23 @@
+{#
+Copyright (C) 2015 Michael Giesler
+
+This file is part of Dembelo.
+
+Dembelo is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Dembelo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License 3 for more details.
+
+You should have received a copy of the GNU Affero General Public License 3
+along with Dembelo. If not, see <http://www.gnu.org/licenses/>.
+#}
+
+
 {% extends 'base.html.twig' %}
 
 {% block body %}
@@ -5,7 +25,7 @@
     <div id="row1" class="row ">
         <div class="col-xs-12">
             <h1>Registrierungsformular</h1>
-            Da wir uns in einer geschlossenen Betaphase befinden, ist eine Registrierung natürlich nicht möglich.
+            Da wir uns in einer geschlossenen Betaphase befinden, ist eine Registrierung noch nicht möglich.
         </div>
     </div>
 </div>

--- a/www/src/DembeloMain/Command/InstallCommand.php
+++ b/www/src/DembeloMain/Command/InstallCommand.php
@@ -133,13 +133,84 @@ class InstallCommand extends ContainerAwareCommand
     {
         $repository = $mongo->getRepository('DembeloMain:Topic');
 
-        $topic = $repository->findOneByName('Lorem');
-
         $this->dummyData['topics'] = array();
 
+        $topic = $repository->findOneByName('Lorem');
         if (is_null($topic)) {
             $topic = new Topic();
             $topic->setName('Lorem');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 2');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 2');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 3');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 3');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 4');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 4');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 5');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 5');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 6');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 6');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 7');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 7');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 8');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 8');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 9');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 9');
             $topic->setStatus(Topic::STATUS_ACTIVE);
             $dm->persist($topic);
         }

--- a/www/src/DembeloMain/Command/InstallCommand.php
+++ b/www/src/DembeloMain/Command/InstallCommand.php
@@ -130,13 +130,84 @@ class InstallCommand extends ContainerAwareCommand
     {
         $repository = $mongo->getRepository('DembeloMain:Topic');
 
-        $topic = $repository->findOneByName('Lorem');
-
         $this->dummyData['topics'] = array();
 
+        $topic = $repository->findOneByName('Lorem');
         if (is_null($topic)) {
             $topic = new Topic();
             $topic->setName('Lorem');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 2');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 2');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 3');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 3');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 4');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 4');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 5');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 5');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 6');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 6');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 7');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 7');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 8');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 8');
+            $topic->setStatus(Topic::STATUS_ACTIVE);
+            $dm->persist($topic);
+        }
+        $this->dummyData['topics'][] = $topic;
+
+        $topic = $repository->findOneByName('Thema 9');
+        if (is_null($topic)) {
+            $topic = new Topic();
+            $topic->setName('Thema 9');
             $topic->setStatus(Topic::STATUS_ACTIVE);
             $dm->persist($topic);
         }

--- a/www/src/DembeloMain/Controller/DefaultController.php
+++ b/www/src/DembeloMain/Controller/DefaultController.php
@@ -32,8 +32,6 @@ use DembeloMain\Document\Topic;
 use DembeloMain\Document\Story;
 use DembeloMain\Document\Textnode;
 
-
-
 /**
  * Class DefaultController
  */
@@ -96,13 +94,13 @@ class DefaultController extends Controller
 
                 $repository = $mongo->getRepository('DembeloMain:Story');
                 $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
-                                                      'status' => Story::STATUS_ACTIVE));
+                                                      'status' => Story::STATUS_ACTIVE, ));
 
                 if (!is_null($story)) {
                     $repository = $mongo->getRepository('DembeloMain:Textnode');
                     $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
                                                            'status' => Textnode::STATUS_ACTIVE,
-                                                           'type' => Textnode::TYPE_INTRODUCTION));
+                                                           'type' => Textnode::TYPE_INTRODUCTION, ));
 
                     if (!is_null($textnodes)) {
                         $textnodeId = $textnodes[0]->getId();
@@ -115,19 +113,17 @@ class DefaultController extends Controller
                 }
 
                 $connection->close();
-            }
-            else {
+            } else {
                 $mongo = $this->get('doctrine_mongodb');
                 $connection = $mongo->getConnection();
 
                 $repository = $mongo->getRepository('DembeloMain:Textnode');
                 $textnodes = $repository->findBy(array('id' => new \MongoId($textnodeId),
-                                                       'status' => Textnode::STATUS_ACTIVE));
+                                                       'status' => Textnode::STATUS_ACTIVE, ));
 
                 $connection->close();
             }
-        }
-        else {
+        } else {
             $mongo = $this->get('doctrine_mongodb');
             $connection = $mongo->getConnection();
 
@@ -137,13 +133,13 @@ class DefaultController extends Controller
 
             $repository = $mongo->getRepository('DembeloMain:Story');
             $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
-                                                  'status' => Story::STATUS_ACTIVE));
+                                                  'status' => Story::STATUS_ACTIVE, ));
 
             if (!is_null($story)) {
                 $repository = $mongo->getRepository('DembeloMain:Textnode');
                 $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
                                                        'status' => Textnode::STATUS_ACTIVE,
-                                                       'type' => Textnode::TYPE_INTRODUCTION));
+                                                       'type' => Textnode::TYPE_INTRODUCTION, ));
             }
 
             $connection->close();

--- a/www/src/DembeloMain/Controller/DefaultController.php
+++ b/www/src/DembeloMain/Controller/DefaultController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler
+/* Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
  *
  * This file is part of Dembelo.
  *
@@ -28,6 +28,7 @@ namespace DembeloMain\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use DembeloMain\Document\Topic;
 
 /**
  * Class DefaultController
@@ -41,6 +42,30 @@ class DefaultController extends Controller
      */
     public function indexAction()
     {
+        $mongo = $this->get('doctrine_mongodb');
+        $connection = $mongo->getConnection();
+
+        if (!$connection->getMongo()) {
+            $connection->connect();
+        }
+
+        $repository = $mongo->getRepository('DembeloMain:Topic');
+        $topics = $repository->findByStatus(Topic::STATUS_ACTIVE);
+
+        $connection->close();
+
+        if (!is_null($topics)) {
+            shuffle($topics);
+            $topicsInfo = array();
+
+            foreach ($topics as $topic) {
+                $topicsInfo[] = array('id' => $topic->getId(),
+                                      'name' => $topic->getName());
+            }
+
+            return $this->render('default/index.html.twig', array('topics' => $topicsInfo));
+        }
+
         return $this->render('default/index.html.twig');
     }
 

--- a/www/src/DembeloMain/Controller/DefaultController.php
+++ b/www/src/DembeloMain/Controller/DefaultController.php
@@ -33,6 +33,7 @@ use DembeloMain\Document\Story;
 use DembeloMain\Document\Textnode;
 
 
+
 /**
  * Class DefaultController
  */
@@ -59,15 +60,7 @@ class DefaultController extends Controller
 
         if (!is_null($topics)) {
             if (count($topics) > 0) {
-                shuffle($topics);
-                $topicsInfo = array();
-
-                foreach ($topics as $topic) {
-                    $topicsInfo[] = array('id' => $topic->getId(),
-                                        'name' => $topic->getName());
-                }
-
-                return $this->render('default/index.html.twig', array('topics' => $topicsInfo));
+                return $this->render('default/index.html.twig', array('topics' => $topics));
             }
         }
 
@@ -102,26 +95,22 @@ class DefaultController extends Controller
                 }
 
                 $repository = $mongo->getRepository('DembeloMain:Story');
-                $stories = $repository->findBy(array('topic_id' => new \MongoId($themeId),
-                                                     'status' => Story::STATUS_ACTIVE));
+                $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
+                                                      'status' => Story::STATUS_ACTIVE));
 
-                if (!is_null($stories)) {
-                    if (count($stories) > 0) {
-                        shuffle($stories);
+                if (!is_null($story)) {
+                    $repository = $mongo->getRepository('DembeloMain:Textnode');
+                    $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
+                                                           'status' => Textnode::STATUS_ACTIVE,
+                                                           'type' => Textnode::TYPE_INTRODUCTION));
 
-                        $repository = $mongo->getRepository('DembeloMain:Textnode');
-                        $textnodes = $repository->findBy(array('story_id' => new \MongoId($stories[0]->getId()),
-                                                               'status' => Textnode::STATUS_ACTIVE,
-                                                               'type' => Textnode::TYPE_INTRODUCTION));
+                    if (!is_null($textnodes)) {
+                        $textnodeId = $textnodes[0]->getId();
+                        $textnodeText = $textnodes[0]->getText();
 
-                        if (!is_null($textnodes)) {
-                            $textnodeId = $textnodes[0]->getId();
-                            $textnodeText = $textnodes[0]->getText();
-
-                            $dm = $mongo->getManager();
-                            $user->setCurrentTextnode($themeId, $textnodeId);
-                            $dm->persist($user);
-                        }
+                        $dm = $mongo->getManager();
+                        $user->setCurrentTextnode($themeId, $textnodeId);
+                        $dm->persist($user);
                     }
                 }
 
@@ -147,18 +136,14 @@ class DefaultController extends Controller
             }
 
             $repository = $mongo->getRepository('DembeloMain:Story');
-            $stories = $repository->findBy(array('topic_id' => new \MongoId($themeId),
-                                                 'status' => Story::STATUS_ACTIVE));
+            $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
+                                                  'status' => Story::STATUS_ACTIVE));
 
-            if (!is_null($stories)) {
-                if (count($stories) > 0) {
-                    shuffle($stories);
-
-                    $repository = $mongo->getRepository('DembeloMain:Textnode');
-                    $textnodes = $repository->findBy(array('story_id' => new \MongoId($stories[0]->getId()),
-                                                        'status' => Textnode::STATUS_ACTIVE,
-                                                        'type' => Textnode::TYPE_INTRODUCTION));
-                }
+            if (!is_null($story)) {
+                $repository = $mongo->getRepository('DembeloMain:Textnode');
+                $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
+                                                       'status' => Textnode::STATUS_ACTIVE,
+                                                       'type' => Textnode::TYPE_INTRODUCTION));
             }
 
             $connection->close();

--- a/www/src/DembeloMain/Controller/DefaultController.php
+++ b/www/src/DembeloMain/Controller/DefaultController.php
@@ -96,23 +96,33 @@ class DefaultController extends Controller
                 $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
                                                       'status' => Story::STATUS_ACTIVE, ));
 
-                if (!is_null($story)) {
-                    $repository = $mongo->getRepository('DembeloMain:Textnode');
-                    $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
-                                                           'status' => Textnode::STATUS_ACTIVE,
-                                                           'type' => Textnode::TYPE_INTRODUCTION, ));
-
-                    if (!is_null($textnodes)) {
-                        $textnodeId = $textnodes[0]->getId();
-                        $textnodeText = $textnodes[0]->getText();
-
-                        $dm = $mongo->getManager();
-                        $user->setCurrentTextnode($themeId, $textnodeId);
-                        $dm->persist($user);
-                    }
+                if (is_null($story)) {
+                    $connection->close();
+                    throw $this->createNotFoundException('No Story for Topic \''.$themeId.'\' found.');
                 }
 
+                $repository = $mongo->getRepository('DembeloMain:Textnode');
+                $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
+                                                       'status' => Textnode::STATUS_ACTIVE,
+                                                       'type' => Textnode::TYPE_INTRODUCTION, ));
+
+                if (is_null($textnodes)) {
+                    $connection->close();
+                    throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
+                }
+
+                if (count($textnodes) <= 0) {
+                    $connection->close();
+                    throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
+                }
+
+                $dm = $mongo->getManager();
+                $user->setCurrentTextnode($themeId, $textnodes[0]->getId());
+                $dm->persist($user);
+
                 $connection->close();
+
+                return $this->render('default/read.html.twig', array('textnodeText' => $textnodes[0]->getText()));
             } else {
                 $mongo = $this->get('doctrine_mongodb');
                 $connection = $mongo->getConnection();
@@ -121,7 +131,19 @@ class DefaultController extends Controller
                 $textnodes = $repository->findBy(array('id' => new \MongoId($textnodeId),
                                                        'status' => Textnode::STATUS_ACTIVE, ));
 
+                if (is_null($textnodes)) {
+                    $connection->close();
+                    throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
+                }
+
+                if (count($textnodes) <= 0) {
+                    $connection->close();
+                    throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
+                }
+
                 $connection->close();
+
+                return $this->render('default/read.html.twig', array('textnodeText' => $textnodes[0]->getText()));
             }
         } else {
             $mongo = $this->get('doctrine_mongodb');
@@ -135,22 +157,29 @@ class DefaultController extends Controller
             $story = $repository->findOneBy(array('topic_id' => new \MongoId($themeId),
                                                   'status' => Story::STATUS_ACTIVE, ));
 
-            if (!is_null($story)) {
-                $repository = $mongo->getRepository('DembeloMain:Textnode');
-                $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
-                                                       'status' => Textnode::STATUS_ACTIVE,
-                                                       'type' => Textnode::TYPE_INTRODUCTION, ));
+            if (is_null($story)) {
+                $connection->close();
+                throw $this->createNotFoundException('No Story for Topic \''.$themeId.'\' found.');
+            }
+
+            $repository = $mongo->getRepository('DembeloMain:Textnode');
+            $textnodes = $repository->findBy(array('story_id' => new \MongoId($story->getId()),
+                                                    'status' => Textnode::STATUS_ACTIVE,
+                                                    'type' => Textnode::TYPE_INTRODUCTION, ));
+
+            if (is_null($textnodes)) {
+                $connection->close();
+                throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
+            }
+
+            if (count($textnodes) <= 0) {
+                $connection->close();
+                throw $this->createNotFoundException('No Textnode for Topic \''.$themeId.'\', Story \''.$story->getId().'\' found.');
             }
 
             $connection->close();
-        }
 
-        if (!is_null($textnodes)) {
-            if (count($textnodes) > 0) {
-                return $this->render('default/read.html.twig', array('textnodeText' => $textnodes[0]->getText()));
-            }
+            return $this->render('default/read.html.twig', array('textnodeText' => $textnodes[0]->getText()));
         }
-
-        return $this->render('default/read.html.twig');
     }
 }

--- a/www/src/DembeloMain/Document/Author.php
+++ b/www/src/DembeloMain/Document/Author.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler <michael@horsemen.de>
+/* Copyright (C) 2015 Michael Giesler
  *
  * This file is part of Dembelo.
  *

--- a/www/src/DembeloMain/Document/ReadPath.php
+++ b/www/src/DembeloMain/Document/ReadPath.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler <michael@horsemen.de>
+/* Copyright (C) 2015 Michael Giesler
  *
  * This file is part of Dembelo.
  *

--- a/www/src/DembeloMain/Document/Story.php
+++ b/www/src/DembeloMain/Document/Story.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler <michael@horsemen.de>
+/* Copyright (C) 2015 Michael Giesler
  *
  * This file is part of Dembelo.
  *

--- a/www/src/DembeloMain/Document/Textnode.php
+++ b/www/src/DembeloMain/Document/Textnode.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler <michael@horsemen.de>
+/* Copyright (C) 2015 Michael Giesler
  *
  * This file is part of Dembelo.
  *

--- a/www/src/DembeloMain/Document/Topic.php
+++ b/www/src/DembeloMain/Document/Topic.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler <michael@horsemen.de>
+/* Copyright (C) 2015 Michael Giesler
  *
  * This file is part of Dembelo.
  *

--- a/www/src/DembeloMain/Document/User.php
+++ b/www/src/DembeloMain/Document/User.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler
+/* Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
  *
  * This file is part of Dembelo.
  *
@@ -61,6 +61,11 @@ class User implements UserInterface, \Serializable
      * @Assert\NotBlank()
      */
     protected $roles;
+
+    /**
+     * @MongoDB\Collection
+     */
+    protected $currentTextnodes;
 
     /**
      * gets the mongodb id
@@ -157,6 +162,20 @@ class User implements UserInterface, \Serializable
         $this->roles = $roles;
     }
 
+    public function getCurrentTextnode($themeId)
+    {
+        if (isset($this->currentTextnodes[$themeId]) === true) {
+            return $this->currentTextnodes[$themeId];
+        }
+
+        return null;
+    }
+
+    public function setCurrentTextnode($themeId, $textnodeId)
+    {
+        $this->currentTextnodes[$themeId] = $textnodeId;
+    }
+
     /**
      * from UserInterface
      */
@@ -177,6 +196,7 @@ class User implements UserInterface, \Serializable
             $this->password,
             // see section on salt below
             // $this->salt,
+            $this->currentTextnodes
         ));
     }
 
@@ -192,7 +212,8 @@ class User implements UserInterface, \Serializable
             $this->email,
             $this->password,
             // see section on salt below
-            // $this->salt
+            // $this->salt,
+            $this->currentTextnodes
             ) = unserialize($serialized);
     }
 }

--- a/www/src/DembeloMain/Document/User.php
+++ b/www/src/DembeloMain/Document/User.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler
+/* Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
  *
  * This file is part of Dembelo.
  *
@@ -61,6 +61,11 @@ class User implements UserInterface, \Serializable
      * @Assert\NotBlank()
      */
     protected $roles;
+
+    /**
+     * @MongoDB\Collection
+     */
+    protected $currentTextnodes;
 
     /**
      * gets the mongodb id
@@ -165,6 +170,20 @@ class User implements UserInterface, \Serializable
         $this->roles = $roles;
     }
 
+    public function getCurrentTextnode($themeId)
+    {
+        if (isset($this->currentTextnodes[$themeId]) === true) {
+            return $this->currentTextnodes[$themeId];
+        }
+
+        return null;
+    }
+
+    public function setCurrentTextnode($themeId, $textnodeId)
+    {
+        $this->currentTextnodes[$themeId] = $textnodeId;
+    }
+
     /**
      * from UserInterface
      */
@@ -185,6 +204,7 @@ class User implements UserInterface, \Serializable
             $this->password,
             // see section on salt below
             // $this->salt,
+            $this->currentTextnodes
         ));
     }
 
@@ -200,7 +220,8 @@ class User implements UserInterface, \Serializable
             $this->email,
             $this->password,
             // see section on salt below
-            // $this->salt
+            // $this->salt,
+            $this->currentTextnodes
             ) = unserialize($serialized);
     }
 }

--- a/www/src/DembeloMain/Document/User.php
+++ b/www/src/DembeloMain/Document/User.php
@@ -170,6 +170,12 @@ class User implements UserInterface, \Serializable
         $this->roles = $roles;
     }
 
+    /**
+     * @brief Gets the last textnode ID of topic \p $themeId the user was reading.
+     * @param string $themeId Theme (= topic) ID.
+     * @retval null There wasn't a textnode ID set for topic \p $themeId yet.
+     * @return Textnode ID.
+     */
     public function getCurrentTextnode($themeId)
     {
         if (isset($this->currentTextnodes[$themeId]) === true) {
@@ -179,6 +185,13 @@ class User implements UserInterface, \Serializable
         return null;
     }
 
+    /**
+     * @brief Sets the textnode ID for topic \p $themeID the user is
+     *     currently reading.
+     * @param string $themeId    Theme ID.
+     * @param string $textnodeId ID of the textnode the user is
+     *     currently reading.
+     */
     public function setCurrentTextnode($themeId, $textnodeId)
     {
         $this->currentTextnodes[$themeId] = $textnodeId;
@@ -204,7 +217,7 @@ class User implements UserInterface, \Serializable
             $this->password,
             // see section on salt below
             // $this->salt,
-            $this->currentTextnodes
+            $this->currentTextnodes,
         ));
     }
 

--- a/www/src/DembeloMain/Document/User.php
+++ b/www/src/DembeloMain/Document/User.php
@@ -174,8 +174,8 @@ class User implements UserInterface, \Serializable
      * Gets the last textnode ID of topic \p $themeId the user was reading.
      *
      * @param string $themeId Theme (= topic) ID.
-     * @retval null There wasn't a textnode ID set for topic \p $themeId yet.
-     * @return Textnode ID.
+     * @return string|null Textnode ID or null, if there wasn't a textnode
+     *     ID set for topic \p $themeId yet.
      */
     public function getCurrentTextnode($themeId)
     {

--- a/www/src/DembeloMain/Document/User.php
+++ b/www/src/DembeloMain/Document/User.php
@@ -171,7 +171,8 @@ class User implements UserInterface, \Serializable
     }
 
     /**
-     * @brief Gets the last textnode ID of topic \p $themeId the user was reading.
+     * Gets the last textnode ID of topic \p $themeId the user was reading.
+     *
      * @param string $themeId Theme (= topic) ID.
      * @retval null There wasn't a textnode ID set for topic \p $themeId yet.
      * @return Textnode ID.
@@ -186,8 +187,9 @@ class User implements UserInterface, \Serializable
     }
 
     /**
-     * @brief Sets the textnode ID for topic \p $themeID the user is
+     * Sets the textnode ID for topic \p $themeID the user is
      *     currently reading.
+     *
      * @param string $themeId    Theme ID.
      * @param string $textnodeId ID of the textnode the user is
      *     currently reading.

--- a/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
+++ b/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
@@ -58,6 +58,8 @@ class DefaultControllerTest extends WebTestCase
         $service = $this->getMockBuilder("Doctrine\Bundle\MongoDBBundle\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $connection = $this->getMockBuilder("Doctrine\MongoDB\Connection")->disableOriginalConstructor()->getMock();
         $repository = $this->getMockBuilder("Doctrine\ODM\MongoDB\DocumentRepository")->disableOriginalConstructor()->getMock();
+        $template = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $response = $this->getMock("Symfony\Component\HttpFoundation\Response");
 
         $container->expects($this->at(0))
             ->method("get")
@@ -85,7 +87,7 @@ class DefaultControllerTest extends WebTestCase
         $story->setName("Lorem I");
         $story->setTopicId("55d2b934658f5cc23c3c986c");
         $story->setStatus(Story::STATUS_ACTIVE);
-        
+
         $repository->expects($this->once())
             ->method("findOneBy")
             ->will($this->returnValue($story));
@@ -102,17 +104,20 @@ class DefaultControllerTest extends WebTestCase
             ->method("findBy")
             ->will($this->returnValue(array($textnode)));
 
+        $container->expects($this->at(2))
+            ->method("get")
+            ->with("templating")
+            ->will($this->returnValue($template));
+        $template->expects($this->once())
+            ->method("renderResponse")
+            ->with("default/read.html.twig", array("textnodeText" => "Lorem ipsum dolor sit amet."))
+            ->will($this->returnValue($response));
 
         $controller = new DefaultController();
         $controller->setContainer($container);
 
-        /* @var $response \Symfony\Component\HttpFoundation\Response */
-        $response = $controller->readAction("55d2b934658f5cc23c3c986c");
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        /** @todo Do result checking. */
-        //$this->assertJsonStringEqualsJsonString('[]', $response->getContent());
-        $this->assertEquals('200', $response->getStatusCode());
+        $result = $controller->readAction("55d2b934658f5cc23c3c986c");
     }
-    
+
     /** @todo Implement testReadWithLogin(). */
 }

--- a/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
+++ b/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Copyright (C) 2015 Michael Giesler
+/* Copyright (C) 2015 Michael Giesler, Stephan Kreutzer
  *
  * This file is part of Dembelo.
  *
@@ -26,6 +26,9 @@
 namespace DembeloMain\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use DembeloMain\Controller\DefaultController;
+use DembeloMain\Document\Story;
+use DembeloMain\Document\Textnode;
 
 /**
  * Class DefaultControllerTest
@@ -48,12 +51,68 @@ class DefaultControllerTest extends WebTestCase
     /**
      * tests the read action
      */
-    public function testRead()
+    public function testReadWithoutLogin()
     {
-        $client = static::createClient();
+        $container = $this->getMock("Symfony\Component\DependencyInjection\ContainerInterface");
+        $securityContext = $this->getMockBuilder("Symfony\Component\Security\Core\SecurityContext")->disableOriginalConstructor()->getMock();
+        $service = $this->getMockBuilder("Doctrine\Bundle\MongoDBBundle\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $connection = $this->getMockBuilder("Doctrine\MongoDB\Connection")->disableOriginalConstructor()->getMock();
+        $repository = $this->getMockBuilder("Doctrine\ODM\MongoDB\DocumentRepository")->disableOriginalConstructor()->getMock();
 
-        $client->request('GET', '/themenfeld/1');
+        $container->expects($this->at(0))
+            ->method("get")
+            ->with($this->equalTo('security.context'))
+            // Security context without any privileges.
+            ->will($this->returnValue($securityContext));
+        $container->expects($this->at(1))
+            ->method("get")
+            ->with($this->equalTo('doctrine_mongodb'))
+            ->will($this->returnValue($service));
+        $service->expects($this->at(0))
+            ->method("getConnection")
+            ->will($this->returnValue($connection));
+        $service->expects($this->at(1))
+            ->method("getRepository")
+            ->with($this->equalTo('DembeloMain:Story'))
+            ->will($this->returnValue($repository));
+        $service->expects($this->at(2))
+            ->method("getRepository")
+            ->with($this->equalTo('DembeloMain:Textnode'))
+            ->will($this->returnValue($repository));
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $story = new Story();
+        $story->setId("55d2b934658f5cc23c3c986d");
+        $story->setName("Lorem I");
+        $story->setTopicId("55d2b934658f5cc23c3c986c");
+        $story->setStatus(Story::STATUS_ACTIVE);
+        
+        $repository->expects($this->once())
+            ->method("findOneBy")
+            ->will($this->returnValue($story));
+
+        $textnode = new Textnode();
+        $textnode->setTopicId("55d2b934658f5cc23c3c986c");
+        $textnode->setStoryId("55d2b934658f5cc23c3c986d");
+        $textnode->setType(Textnode::TYPE_INTRODUCTION);
+        $textnode->setStatus(Textnode::STATUS_ACTIVE);
+        $textnode->setId(1);
+        $textnode->setText("Lorem ipsum dolor sit amet.");
+
+        $repository->expects($this->once())
+            ->method("findBy")
+            ->will($this->returnValue(array($textnode)));
+
+
+        $controller = new DefaultController();
+        $controller->setContainer($container);
+
+        /* @var $response \Symfony\Component\HttpFoundation\Response */
+        $response = $controller->readAction("55d2b934658f5cc23c3c986c");
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        /** @todo Do result checking. */
+        //$this->assertJsonStringEqualsJsonString('[]', $response->getContent());
+        $this->assertEquals('200', $response->getStatusCode());
     }
+    
+    /** @todo Implement testReadWithLogin(). */
 }

--- a/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
+++ b/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
@@ -49,7 +49,7 @@ class DefaultControllerTest extends WebTestCase
     }
 
     /**
-     * @brief Tests the action of reading a textnode without an active
+     * Tests the action of reading a textnode without an active
      *     user session.
      */
     public function testReadWithoutLogin()

--- a/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
+++ b/www/src/DembeloMain/Tests/Controller/DefaultControllerTest.php
@@ -49,7 +49,8 @@ class DefaultControllerTest extends WebTestCase
     }
 
     /**
-     * tests the read action
+     * @brief Tests the action of reading a textnode without an active
+     *     user session.
      */
     public function testReadWithoutLogin()
     {

--- a/www/src/DembeloMain/Tests/Document/UserTest.php
+++ b/www/src/DembeloMain/Tests/Document/UserTest.php
@@ -140,7 +140,8 @@ class UserTest extends WebTestCase
         $this->user->setId('id');
         $this->user->setEmail('email');
         $this->user->setPassword('pw');
-        $this->assertEquals(serialize(array('id', 'email', 'pw')), $this->user->serialize());
+        $this->user->setCurrentTextnode('55cd2a9808985ca80c3c986c', '55cd2a9808985ca80c3c9877');
+        $this->assertEquals(serialize(array('id', 'email', 'pw', array('55cd2a9808985ca80c3c986c' => '55cd2a9808985ca80c3c9877'))), $this->user->serialize());
     }
 
     /**
@@ -148,11 +149,12 @@ class UserTest extends WebTestCase
      */
     public function testUnserialize()
     {
-        $serialized = serialize(array('id', 'email', 'pw'));
+        $serialized = serialize(array('id', 'email', 'pw', array('55cd2a9808985ca80c3c986c' => '55cd2a9808985ca80c3c9877')));
         $this->user->unserialize($serialized);
         $this->assertEquals('id', $this->user->getId());
         $this->assertEquals('email', $this->user->getEmail());
         $this->assertEquals('pw', $this->user->getPassword());
+        $this->assertEquals('55cd2a9808985ca80c3c9877', $this->user->getCurrentTextnode('55cd2a9808985ca80c3c986c'));
     }
 
     /**


### PR DESCRIPTION
The change from topic IDs counted from 1 to the internal MongoDB IDs on the main page is necessary because the Story object doesn't know about the counted ID. Additionally, the topics get randomly shuffled. In a future change, this may not take place if the user is logged in, so his latest topics stay in place as long as none of the topics gets downvoted/disabled. The rendered result doesn't get cached at the moment, so for unregistered users, there might be the need to wait with the next shuffle for a certain time span. The InstallCommand inserts 9 topics now, so the effect of this change is demonstrated. Only the “Lorem” topic is one with example data behind it, if it is excluded from the list, just reload the page until it shows up.
