### PR TITLE
overridden error templates

### DIFF
--- a/www/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/www/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,13 @@
+{% extends 'DembeloMain::base.html.twig' %}
+{% block title %}
+    Fehler: {{ status_text }}
+{% endblock %}
+{% block body %}
+    <h1>Es ist ein Fehler aufgetreten</h1>
+    <h2>"{{ status_code }} {{ status_text }}".</h2>
+
+    <div>
+        Leider ist ein unerwarteter Fehler ist aufgetreten. Wir entschuldigen die Umstände und beheben umgehend das Problem.
+        Bitte versuchen Sie es später erneut.
+    </div>
+{% endblock %}

--- a/www/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/www/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -1,0 +1,11 @@
+{% extends 'DembeloMain::base.html.twig' %}
+{% block title %}404 Seite nicht gefunden{% endblock %}
+
+{% block body %}
+    <h1>Seite nicht gefunden</h1>
+
+    <p>
+        Die angeforderte Seite konnte leider nicht gefunden werden. Bitte überprüfen Sie die URL auf Tippfehler oder kehren Sie zur
+        <a href="{{ path('mainpage') }}">Startseite</a> zurück.
+    </p>
+{% endblock %}


### PR DESCRIPTION
In der DEV-Environment werden die Error-Seiten nicht dargestellt, um dies jedoch reproduzieren zu können folgende URL aufrufen:

http://dembelo.int/app_dev.php/_error/404
http://dembelo.int/app_dev.php/_error/500
http://dembelo.int/app_dev.php/_error/{status_code}

Weitere Infos siehe http://symfony.com/doc/current/controller/error_pages.html
#216
